### PR TITLE
fixed getting output filename

### DIFF
--- a/mothur_py/core.py
+++ b/mothur_py/core.py
@@ -275,10 +275,7 @@ class MothurCommand:
                         # because multiple files with the same extension can be returned we save them in a list
                         if parse_output_flag:
                             output_file_path = line.split(os.path.sep)
-                            if len(output_file_path) == 1:
-                                output_file_name = output_file_path
-                            else:
-                                output_file_name = output_file_path[-1]
+                            output_file_name = output_file_path[-1]
                             output_file_type = output_file_name.rsplit('.', 1)[-1]
                             new_output_files[output_file_type].append(output_file_name)
 


### PR DESCRIPTION
When I provided the FASTQ files relatively in the current working directory it was splitting their paths with `os.path.sep` but not assigning them with `output_file_name = output_file_path[0]`. So at the end, the code was trying to use `rsplit` on a list which produced following error:

```
Traceback (most recent call last):
  File "contig-assembly.py", line 53, in <module>
    main()
  File "contig-assembly.py", line 50, in main
    m.make.contigs(ffastq=forward_file, rfastq=reverse_file, trimoverlap='T')
  File "/usr/local/lib/python3.6/site-packages/mothur_py/core.py", line 284, in __call__
    output_file_type = output_file_name.rsplit('.', 1)[-1]
AttributeError: 'list' object has no attribute 'rsplit'
```

I just got rid of the `if` as I think it should work this way anyways.
