### PR TITLE
Fix compatibility issue with Python 3.10+

### DIFF
--- a/mothur_py/utils.py
+++ b/mothur_py/utils.py
@@ -7,7 +7,7 @@ For full license terms see LICENSE.txt
 
 """
 
-import collections
+from collections.abc import Sequence
 
 
 def format_mothur_params(*args, **kwargs):
@@ -60,7 +60,7 @@ def convert_mothur_iterable(item):
     """Converts python iterable into a format that is compatible with mothur."""
 
     # convert python iterable, excluding strings, to mothur list
-    if isinstance(item, collections.Sequence) and not isinstance(item, str):
+    if isinstance(item, Sequence) and not isinstance(item, str):
         # mothur lists are hyphen separated
         return ('-').join(item)
     else:


### PR DESCRIPTION
When I tried to use this lib, I was receiving some error on `collections` module.

<img width="943" height="307" alt="mothur-error" src="https://github.com/user-attachments/assets/741499c3-dead-4860-8b39-463c92051ac9" />

Since version 3.10 of Python, the `collections` module was migrated to `collections.abc`, what can be seen on its [documentation](https://docs.python.org/3/library/collections.abc.html).